### PR TITLE
Fixe ineffecient implmentation in ISTFTHead

### DIFF
--- a/vocos/heads.py
+++ b/vocos/heads.py
@@ -54,10 +54,15 @@ class ISTFTHead(FourierHead):
         mag, p = x.chunk(2, dim=1)
         mag = torch.exp(mag)
         mag = torch.clip(mag, max=1e2)  # safeguard to prevent excessively large magnitudes
+        # wrapping happens here. These two lines produce real and imaginary value
         x = torch.cos(p)
         y = torch.sin(p)
-        phase = torch.atan2(y, x)
-        S = mag * torch.exp(phase * 1j)
+        # recalculating phase here does not produce anything new
+        # only costs time
+        # phase = torch.atan2(y, x)
+        # S = mag * torch.exp(phase * 1j)
+        # better directly produce the complex value 
+        S = mag * (x + 1j * y)
         audio = self.istft(S)
         return audio
 


### PR DESCRIPTION
Thanks for sharing the code of this study. Reading the paper on arxiv I was astonished to see a highly redundant phase unwrapping code. I explain the problem in the code extract below

```
p = predicted phase
# calculate cos/sin with phase wrapping 
x = torch.cos(p)
y = torch.sin(p)
# recalculate wrapped phase
phase = torch.atan2(y, x)
# calculate complex values (here with unit magnitude) from the 1j * phase
S = torch.exp(phase * 1j)
```

I'd suggest changing into a 100% equivalent code that is about 3 times faster:

```
p = predicted phase
# calculate cos/sin with phase wrapping 
x = torch.cos(p)
y = torch.sin(p)
S = x + 1j  * y
```

You may not know that exp(jp) internally calculates `cos(p) +1j * sin(p)`. On the other hand, recalculating 
the phase after the first pass through cos/sin does produce a warped phase but does not avoid any 
of the numerical problems that may arise when p is >> 1. The problem happened already within 
cos/sin. The final S will always be what you get for the proposed change, avoiding the call 
to atan as well as the call to `exp(1j * p)`. In the end, this will be three times faster

Please find a benchmark proving the speed advantage and the equivalence of the results here

https://github.com/roebel/vocos/blob/main/Improving_Vocos_vocoder_phase_unwrapping_issue.ipynb
 
for a benchmark.